### PR TITLE
drop uvloop, ujson dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-ujson
-uvloop
 sanic>=0.7.0


### PR DESCRIPTION
`sanic` can work independently without `uvloop` and `ujson` .