### PR TITLE
Explicitly add dependency on `setuptools`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+setuptools>=40.0
 sanic>=18.12.0


### PR DESCRIPTION
Inside the `config.py` file we have an explicit import of `pkg_resources` which is provided by `setuptools`.

https://github.com/ashleysommer/sanicpluginsframework/blob/02e0668107714d56a59f1f6ef478e719dfbce957/spf/config.py#L8

Not all Python distribution comes with that bundled which can cause fail at runtime since it cannot find `pkg_resources`.
I'm pinning the version at `>=40.0` which is the same one used in `pytest` and seems like `pytest` is also a common dependency here.